### PR TITLE
Fix registry export script

### DIFF
--- a/Regedit-Scripts/detect-reg-for-autodesk-v2.ps1
+++ b/Regedit-Scripts/detect-reg-for-autodesk-v2.ps1
@@ -37,10 +37,10 @@ foreach ($subkey in $subkeys) {
 }
 
 # Sort the results by ProductName
-#$sortedResult = $result | Sort-Object -Property ProductName
+$sortedResult = $result | Sort-Object -Property ProductName
 
 # Export the sorted result to screen and file
-#$sortedResult | Format-Table -AutoSize | Tee-Object -FilePath $outputFile
+$sortedResult | Format-Table -AutoSize | Tee-Object -FilePath $outputFile
 
 # Export the sorted result to file in CSV format
 $sortedResult | Export-Csv -Path $outputFile -NoTypeInformation


### PR DESCRIPTION
## Summary
- correct the sorting logic and output commands in the `detect-reg-for-autodesk-v2.ps1` script

## Testing
- `pwsh Regedit-Scripts/detect-reg-for-autodesk-v2.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684040c1a5bc832fbd35c86544686a19